### PR TITLE
Stop if one of the build fails

### DIFF
--- a/build-images.sh
+++ b/build-images.sh
@@ -43,7 +43,10 @@ main() {
     build_kexec_bundle "$tag" "$arch" "$tmp"
     build_netboot_image "$tag" "$arch" "$tmp"
   )
-
+  if [ ! "${#assets[@]}" -eq "3" ]; then
+    echo "Missing build asset"
+    exit 1
+  fi
   for asset in "${assets[@]}"; do
     pushd "$(dirname "$asset")"
     sha256sum "$(basename "$asset")" >> "$TMP/sha256sums"


### PR DESCRIPTION
Using process substitution doesn't handle errors.
Check that we have the expected build assets before we continue.
