### PR TITLE
kexec-installer: add virtual and noninteractive variants for smaller images

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -17,14 +17,24 @@
   in {
     packages = forAllSystems (system: let
       netboot = nixpkgs: (import (nixpkgs + "/nixos/release.nix") {}).netboot.${system};
-      kexec-installer = nixpkgs: (nixpkgs.legacyPackages.${system}.nixos [self.nixosModules.kexec-installer]).config.system.build.kexecTarball;
+      kexec-installer = nixpkgs: modules: (nixpkgs.legacyPackages.${system}.nixos (modules ++ [self.nixosModules.kexec-installer])).config.system.build.kexecTarball;
     in {
       netboot-nixos-unstable = netboot nixos-unstable;
       netboot-nixos-2211 = netboot nixos-2211;
-      kexec-installer-nixos-unstable = kexec-installer nixos-unstable;
-      kexec-installer-nixos-2211 = kexec-installer nixos-2211;
+      kexec-installer-nixos-unstable = kexec-installer nixos-unstable [];
+      kexec-installer-nixos-2211 = kexec-installer nixos-2211 [];
+
+      kexec-installer-nixos-unstable-noninteractive = kexec-installer nixos-unstable [ self.nixosModules.noninteractive ];
+      kexec-installer-nixos-2211-noninteractive = kexec-installer nixos-2211 [ self.nixosModules.noninteractive ];
+
+      kexec-installer-nixos-unstable-virtual-noninteractive = kexec-installer nixos-unstable [ self.nixosModules.noninteractive self.nixosModules.virtual ];
+      kexec-installer-nixos-2211-virtual-noninteractive = kexec-installer nixos-2211 [ self.nixosModules.noninteractive self.nixosModules.virtual ];
     });
-    nixosModules.kexec-installer = import ./nix/kexec-installer/module.nix;
+    nixosModules = {
+      kexec-installer = ./nix/kexec-installer/module.nix;
+      noninteractive = ./nix/noninteractive.nix;
+      virtual = ./nix/virtual.nix;
+    };
     checks.x86_64-linux = let
       pkgs = nixos-unstable.legacyPackages.x86_64-linux;
     in {

--- a/nix/noninteractive.nix
+++ b/nix/noninteractive.nix
@@ -11,8 +11,6 @@
   # among others, this prevents carrying a stdenv with gcc in the image
   system.extraDependencies = lib.mkForce [];
 
-  # prevents texinfoInteractive
-  documentation.enable = lib.mkForce false;
 
   # prevents shipping nixpkgs, unnecessary if system is evaluated externally
   nix.registry = lib.mkForce {};

--- a/nix/noninteractive.nix
+++ b/nix/noninteractive.nix
@@ -1,0 +1,31 @@
+# This module optimizes for non-interactive deployments by remove some store paths
+# which are primarily useful for interactive installations.
+
+{ config, lib, ... }: {
+  disabledModules = [
+    # This module adds values to multiple lists (systemPackages, supportedFilesystems)
+    # which are impossible/unpractical to remove, so we disable the entire module.
+    "profiles/base.nix"
+  ];
+
+  # among others, this prevents carrying a stdenv with gcc in the image
+  system.extraDependencies = lib.mkForce [];
+
+  # prevents texinfoInteractive
+  documentation.enable = lib.mkForce false;
+
+  # prevents shipping nixpkgs, unnecessary if system is evaluated externally
+  nix.registry = lib.mkForce {};
+
+  # would pull in nano
+  programs.nano.syntaxHighlight = lib.mkForce false;
+
+  # prevents nano, rsync, strace
+  environment.defaultPackages = lib.mkForce [];
+
+  # zfs support is accidentally disabled by excluding base.nix, re-enable it
+  boot = {
+    kernelModules = [ "zfs" ];
+    extraModulePackages = [ config.boot.kernelPackages.zfs ];
+  };
+}

--- a/nix/virtual.nix
+++ b/nix/virtual.nix
@@ -1,0 +1,5 @@
+# This module optimizes for deployments to virtualized hosts.
+
+{ lib, ... }: {
+  hardware.enableRedistributableFirmware = lib.mkForce false;
+}


### PR DESCRIPTION
This adds kexec-installer variants with:

- noninteractive
  - removes store paths which are meant for interactive installation: nano, vim, rsync, strace, stdenv (gcc), nixpkgs checkout, texinfo, w3m, and a few others
  - disables `base.nix` module, which also drops a few `boot.supportedFilesystems` (including reiserfs and zfs)
- virtual
  - disables redistributable firmware, which saves a lot of space and shouldn't be necessary for installation into virtual machines

The goal was to use nix-community/nixos-anywhere on a CPX11 (2GB) Hetzner Cloud instance, where kexec failed before, but installation succeeds with the smaller variants.
I'm not convinced by the attribute names (if nested packages were blessed by the flakes schema, I'd have gone with that).

```bash
$ du -h $(nix build --print-out-paths .\#kexec-installer-nixos-2211 .\#kexec-installer-nixos-2211-noninteractive .\#kexec-installer-nixos-2211-virtual-noninteractive)
822M	/nix/store/206frcls0sl6wlcjklq5p33sf5gl2y2v-kexec-tarball
686M	/nix/store/wk4h7vwssmnmqqgbl24hr393zx3hrpdg-kexec-tarball
299M	/nix/store/3m040vvwmrpi4frsz7w06pmrkybs25fx-kexec-tarball
```