### PR TITLE
get rid of virtual variant again

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Kexec is a mechanism in Linux to load a new kernel from a running Linux to
 replace the current kernel. This is useful for booting the Nixos installer from
 existing Linux distributions, such as server provider that do not offer a NixOS
 option. After running kexec, the NixOS installer exists only in memory. At the
-time of writing, this requires at least 2.5GB of physical RAM (swap does not
+time of writing, this requires at least 1.5GB of physical RAM (swap does not
 count) in the system. If not enough RAM is available, the initrd cannot be
 loaded. Because the NixOS runs only in RAM, users can reformat all the system's
 discs to prepare for a new NixOS installation.
@@ -22,7 +22,7 @@ discs to prepare for a new NixOS installation.
 It can be booted as follows by running these commands as root:
 
 ```
-curl -L https://github.com/nix-community/nixos-images/releases/download/nixos-unstable/nixos-kexec-installer-x86_64-linux.tar.gz | tar -xzf- -C /root
+curl -L https://github.com/nix-community/nixos-images/releases/download/nixos-unstable/nixos-kexec-installer-noninteractive-x86_64-linux.tar.gz | tar -xzf- -C /root
 /root/kexec/run
 ```
 
@@ -37,5 +37,5 @@ The kexec installer comes with the following features:
 
 The actual kexec happens with a slight delay (6s).  This allows for easier
 integration into automated nixos installation scripts, since you can cleanly
-disconnect from the running machine before the kexec takes place.  The tarball
+disconnect from the running machine before the kexec takes place. The tarball
 is also designed to be run from NixOS, which can be useful for new installations

--- a/build-images.sh
+++ b/build-images.sh
@@ -31,7 +31,6 @@ main() {
   trap 'rm -rf -- "$tmp"' EXIT
   (
     build_kexec_installer "$tag" "$arch" "$tmp" ""
-    build_kexec_installer "$tag" "$arch" "$tmp" "-virtual-noninteractive"
     build_kexec_installer "$tag" "$arch" "$tmp" "-noninteractive"
     build_netboot_image "$tag" "$arch" "$tmp"
   ) | readarray -t assets

--- a/flake.nix
+++ b/flake.nix
@@ -32,20 +32,10 @@
         { system.kexec-installer.name = "nixos-kexec-installer-noninteractive"; }
         self.nixosModules.noninteractive 
       ];
-
-      kexec-installer-nixos-unstable-virtual-noninteractive = kexec-installer nixos-unstable [ 
-        { system.kexec-installer.name = "nixos-kexec-installer-virtual-noninteractive"; }
-        self.nixosModules.noninteractive self.nixosModules.virtual 
-      ];
-      kexec-installer-nixos-2211-virtual-noninteractive = kexec-installer nixos-2211 [ 
-        { system.kexec-installer.name = "nixos-kexec-installer-virtual-noninteractive"; }
-        self.nixosModules.noninteractive self.nixosModules.virtual 
-      ];
     });
     nixosModules = {
       kexec-installer = ./nix/kexec-installer/module.nix;
       noninteractive = ./nix/noninteractive.nix;
-      virtual = ./nix/virtual.nix;
     };
     checks.x86_64-linux = let
       pkgs = nixos-unstable.legacyPackages.x86_64-linux;

--- a/nix/kexec-installer/test.nix
+++ b/nix/kexec-installer/test.nix
@@ -21,7 +21,7 @@ in makeTest' {
         (modulesPath + "/profiles/minimal.nix")
       ];
 
-      virtualisation.memorySize = 2048;
+      virtualisation.memorySize = 1024 + 512;
       virtualisation.diskSize = 4 * 1024;
       virtualisation.useBootLoader = true;
       virtualisation.useEFIBoot = true;

--- a/nix/kexec-installer/test.nix
+++ b/nix/kexec-installer/test.nix
@@ -21,7 +21,7 @@ in makeTest' {
         (modulesPath + "/profiles/minimal.nix")
       ];
 
-      virtualisation.memorySize = 2 * 1024 + 767;
+      virtualisation.memorySize = 2048;
       virtualisation.diskSize = 4 * 1024;
       virtualisation.useBootLoader = true;
       virtualisation.useEFIBoot = true;
@@ -68,6 +68,7 @@ in makeTest' {
       environment.systemPackages = [ pkgs.hello ];
       imports = [
         ./module.nix
+        ../noninteractive.nix
       ];
     };
 

--- a/nix/noninteractive.nix
+++ b/nix/noninteractive.nix
@@ -26,4 +26,7 @@
     kernelModules = [ "zfs" ];
     extraModulePackages = [ config.boot.kernelPackages.zfs ];
   };
+
+  # we can drop this after 23.05 has been released, which has this set by default
+  hardware.enableRedistributableFirmware = lib.mkForce false;
 }

--- a/nix/virtual.nix
+++ b/nix/virtual.nix
@@ -1,5 +1,0 @@
-# This module optimizes for deployments to virtualized hosts.
-
-{ lib, ... }: {
-  hardware.enableRedistributableFirmware = lib.mkForce false;
-}


### PR DESCRIPTION
In unstable this has now the same size as the noninteractive one.