### PR TITLE
feat: speed up kexec boot

### DIFF
--- a/nix/kexec-installer/kexec-run.sh
+++ b/nix/kexec-installer/kexec-run.sh
@@ -54,7 +54,7 @@ find . | cpio -o -H newc | gzip -9 >> "$SCRIPT_DIR/initrd"
 
 # Dropped --kexec-syscall-auto because it broke on GCP...
 "$SCRIPT_DIR/kexec" --load "$SCRIPT_DIR/bzImage" \
-  --initrd="$SCRIPT_DIR/initrd" \
+  --initrd="$SCRIPT_DIR/initrd" --no-checks \
   --command-line "init=$init $kernelParams"
 
 # Disconnect our background kexec from the terminal


### PR DESCRIPTION
Do not check if the new kernel is correctly copied in memory.

On ARM64 (Hetzner CAX21, CAX41) it improves boot from 4 minutes to a few seconds.

Option introduced in kexec-tools here: https://github.com/horms/kexec-tools/commit/0481e9ed61ef80b3d851bb96b0c70a3d4a112c8b More on this https://eastrivervillage.com/kexec-tools-with-the-hidden-purgatory/