### PR TITLE
noninteractive: Add zfs packages

### DIFF
--- a/nix/noninteractive.nix
+++ b/nix/noninteractive.nix
@@ -21,6 +21,7 @@
   environment.defaultPackages = lib.mkForce [ 
     pkgs.rsync 
     pkgs.parted
+    pkgs.zfs
   ];
 
   # zfs support is accidentally disabled by excluding base.nix, re-enable it


### PR DESCRIPTION
ZFS related binaries like `zpool`, `zfs` and `zdb` were missing from the `nixos-kexec-installer-noninteractive` image.

This PR fixes the following issues encountered during testing with OVH "Public Cloud" VMs using [nixos-anywhere](https://github.com/numtide/nixos-anywhere):

- Machines pre-installed with Debian 11 print error `zdb: command not found` during `disk-deactivate` when trying to remove `/dev/sda14`

- Trying to create a simple zpool + zfs dataset that is mounted as `/` fails with `zpool: command not found` On OVH machines the installer would print an error being unable to locate the `zdb` binary,