### PR TITLE
kexec-installer: re-enable kexec-syscall-auto

### DIFF
--- a/nix/kexec-installer/kexec-run.sh
+++ b/nix/kexec-installer/kexec-run.sh
@@ -52,8 +52,8 @@ done
 
 find . | cpio -o -H newc | gzip -9 >> "$SCRIPT_DIR/initrd"
 
-# Dropped --kexec-syscall-auto because it broke on GCP...
 if ! "$SCRIPT_DIR/kexec" --load "$SCRIPT_DIR/bzImage" \
+  --kexec-syscall-auto \
   --initrd="$SCRIPT_DIR/initrd" --no-checks \
   --command-line "init=$init $kernelParams"; then
   echo "kexec failed, dumping dmesg"


### PR DESCRIPTION
Seems like GCP changed something about their boot process and the same instance types that failed to kexec, now just works. This fixes secureboot as well: https://github.com/nix-community/nixos-images/issues/128