### PR TITLE
add nix-settings from srvos

### DIFF
--- a/nix/installer.nix
+++ b/nix/installer.nix
@@ -23,6 +23,10 @@
   # for zapping of disko
   environment.systemPackages = [ pkgs.jq ];
 
+  imports = [
+    ./nix-settings.nix
+  ];
+
   systemd.services.log-network-status = {
     wantedBy = [ "multi-user.target" ];
     # No point in restarting this. We just need this after boot

--- a/nix/nix-settings.nix
+++ b/nix/nix-settings.nix
@@ -1,0 +1,28 @@
+# take from srvos
+{ lib, ... }:
+{
+  # Fallback quickly if substituters are not available.
+  nix.settings.connect-timeout = 5;
+
+  # Enable flakes
+  nix.settings.experimental-features = [
+    "nix-command"
+    "flakes"
+    "repl-flake"
+  ];
+
+  # The default at 10 is rarely enough.
+  nix.settings.log-lines = lib.mkDefault 25;
+
+  # Avoid disk full issues
+  nix.settings.max-free = lib.mkDefault (3000 * 1024 * 1024);
+  nix.settings.min-free = lib.mkDefault (512 * 1024 * 1024);
+
+  # TODO: cargo culted.
+  nix.daemonCPUSchedPolicy = lib.mkDefault "batch";
+  nix.daemonIOSchedClass = lib.mkDefault "idle";
+  nix.daemonIOSchedPriority = lib.mkDefault 7;
+
+  # Avoid copying unnecessary stuff over SSH
+  nix.settings.builders-use-substitutes = true;
+}


### PR DESCRIPTION
if used as a recovery system, it's useful to have flakes etc enabled.