### PR TITLE
also copy machine-id into installer

### DIFF
--- a/nix/installer.nix
+++ b/nix/installer.nix
@@ -58,5 +58,8 @@
     fi
     install -m 400 ssh/ssh_host_* /mnt-root/etc/ssh
     cp *.json /mnt-root/root/network/
+    if [[ -f machine-id ]]; then
+      cp machine-id /mnt-root/etc/machine-id
+    fi
   '';
 }

--- a/nix/kexec-installer/kexec-run.sh
+++ b/nix/kexec-installer/kexec-run.sh
@@ -50,6 +50,8 @@ done
 "$SCRIPT_DIR/ip" -4 --json route > routes-v4.json
 "$SCRIPT_DIR/ip" -6 --json route > routes-v6.json
 
+[ -f /etc/machine-id ] && cp /etc/machine-id machine-id
+
 find . | cpio -o -H newc | gzip -9 >> "$SCRIPT_DIR/initrd"
 
 if ! "$SCRIPT_DIR/kexec" --load "$SCRIPT_DIR/bzImage" \


### PR DESCRIPTION
This can help with keeping the same dhcp leases when the dhcp server uses DUID rather than mac addresses