### PR TITLE
build 23.11 instead of 23.05

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         tag:
-          - nixos-23.05
+          - nixos-23.11
           - nixos-unstable
         os:
           - nscloud-ubuntu-22.04-arm64-4x16

--- a/flake.lock
+++ b/flake.lock
@@ -1,17 +1,17 @@
 {
   "nodes": {
-    "nixos-2305": {
+    "nixos-2311": {
       "locked": {
-        "lastModified": 1701805708,
-        "narHash": "sha256-hh0S14E816Img0tPaNQSEKFvSscSIrvu1ypubtfh6M4=",
+        "lastModified": 1702128801,
+        "narHash": "sha256-nU69ZNl1pCXEtNdyHT1/nA4NnXWsWUMpEg937BNecbo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0561103cedb11e7554cf34cea81e5f5d578a4753",
+        "rev": "8ae56eaea9054590c57f9509341601f05cbb92d7",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "release-23.05",
+        "ref": "release-23.11",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -34,7 +34,7 @@
     },
     "root": {
       "inputs": {
-        "nixos-2305": "nixos-2305",
+        "nixos-2311": "nixos-2311",
         "nixos-unstable": "nixos-unstable"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "NixOS images";
 
   inputs.nixos-unstable.url = "github:NixOS/nixpkgs/nixos-unstable-small";
-  inputs.nixos-2305.url = "github:NixOS/nixpkgs/release-23.05";
+  inputs.nixos-2311.url = "github:NixOS/nixpkgs/release-23.11";
 
   nixConfig.extra-substituters = [
     "https://cache.garnix.io"
@@ -11,7 +11,7 @@
     "cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g="
   ];
 
-  outputs = { self, nixos-unstable, nixos-2305 }:
+  outputs = { self, nixos-unstable, nixos-2311 }:
     let
       supportedSystems = [ "aarch64-linux" "x86_64-linux" ];
       forAllSystems = nixos-unstable.lib.genAttrs supportedSystems;
@@ -25,26 +25,31 @@
         in
         {
           netboot-nixos-unstable = netboot nixos-unstable;
-          netboot-nixos-2305 = netboot nixos-2305;
+          netboot-nixos-2311 = netboot nixos-2311;
           kexec-installer-nixos-unstable = kexec-installer nixos-unstable [ ];
-          kexec-installer-nixos-2305 = kexec-installer nixos-2305 [ ];
+          kexec-installer-nixos-2311 = kexec-installer nixos-2311 [ ];
 
           kexec-installer-nixos-unstable-noninteractive = kexec-installer nixos-unstable [
             {
               system.kexec-installer.name = "nixos-kexec-installer-noninteractive";
-              system.installer.channel.enable = false; # TODO: enable this also in the 23.11 edition, once we have it.
+              system.installer.channel.enable = false;
             }
             self.nixosModules.noninteractive
           ];
-          kexec-installer-nixos-2305-noninteractive = kexec-installer nixos-2305 [
-            { system.kexec-installer.name = "nixos-kexec-installer-noninteractive"; }
+          kexec-installer-nixos-2311-noninteractive = kexec-installer nixos-2311 [
+            {
+              system.kexec-installer.name = "nixos-kexec-installer-noninteractive";
+              system.installer.channel.enable = false;
+            }
             self.nixosModules.noninteractive
           ];
 
           netboot-installer-nixos-unstable = netboot-installer nixos-unstable [
-            { system.installer.channel.enable = false; } # TODO: enable this also in the 23.11 edition, once we have it.
+            { system.installer.channel.enable = false; }
           ];
-          netboot-installer-nixos-2305 = netboot-installer nixos-2305 [ ];
+          netboot-installer-nixos-2311 = netboot-installer nixos-2311 [
+            { system.installer.channel.enable = false; }
+          ];
         });
       nixosModules = {
         kexec-installer = ./nix/kexec-installer/module.nix;
@@ -67,8 +72,8 @@
             shellcheck ${(pkgs.nixos [self.nixosModules.kexec-installer]).config.system.build.kexecRun}
             touch $out
           '';
-          kexec-installer-2305 = nixos-2305.legacyPackages.x86_64-linux.callPackage ./nix/kexec-installer/test.nix {
-            kexecTarball = self.packages.x86_64-linux.kexec-installer-nixos-2305-noninteractive;
+          kexec-installer-2311 = nixos-2311.legacyPackages.x86_64-linux.callPackage ./nix/kexec-installer/test.nix {
+            kexecTarball = self.packages.x86_64-linux.kexec-installer-nixos-2311-noninteractive;
           };
         };
     };

--- a/nix/noninteractive.nix
+++ b/nix/noninteractive.nix
@@ -55,7 +55,4 @@
   };
 
   networking.hostId = lib.mkDefault "8425e349";
-
-  # we can drop this after 23.05 has been released, which has this set by default
-  hardware.enableRedistributableFirmware = lib.mkForce false;
 }


### PR DESCRIPTION
I am replacing the old release here because only the current one has been built so far and existing installer images for 23.05 are probably good enough as long as that's still supported?

 Happy to add 23.11 as an additional one if there's a use-case I am missing.