### PR TITLE
add rsync to installer

### DIFF
--- a/nix/installer.nix
+++ b/nix/installer.nix
@@ -23,8 +23,12 @@
   systemd.network.enable = true;
   networking.dhcpcd.enable = false;
 
-  # for zapping of disko
-  environment.systemPackages = [ pkgs.jq ];
+  environment.systemPackages = [
+    # for zapping of disko
+    pkgs.jq
+    # for copying extra files of nixos-anywhere
+    pkgs.rsync
+  ];
 
   imports = [
     ./nix-settings.nix


### PR DESCRIPTION
The rsync is missing in the step of copying extra files of nixos-anywhere installation.