### PR TITLE
kexec-run: Get pubkeys for DOAS_USER.

### DIFF
--- a/nix/kexec-installer/kexec-run.sh
+++ b/nix/kexec-installer/kexec-run.sh
@@ -27,6 +27,10 @@ extractPubKeys() {
 }
 extractPubKeys /root
 
+if test -n "${DOAS_USER-}"; then
+  SUDO_USER="$DOAS_USER"
+fi
+
 if test -n "${SUDO_USER-}"; then
   sudo_home=$(sh -c "echo ~$SUDO_USER")
   extractPubKeys "$sudo_home"


### PR DESCRIPTION
doas is a smaller replacement for sudo, used by some distributions (such as Alpine).