### PR TITLE
add disko to all installer

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -16,31 +16,33 @@
       packages = forAllSystems (system:
         let
           netboot = nixpkgs: (import (nixpkgs + "/nixos/release.nix") { }).netboot.${system};
-          kexec-installer = nixpkgs: modules: (nixpkgs.legacyPackages.${system}.nixos (modules ++ [ self.nixosModules.kexec-installer ])).config.system.build.kexecTarball;
+          kexec-installer = nixpkgs: module: (nixpkgs.legacyPackages.${system}.nixos [ module self.nixosModules.kexec-installer ]).config.system.build.kexecTarball;
           netboot-installer = nixpkgs: (nixpkgs.legacyPackages.${system}.nixos [ self.nixosModules.netboot-installer ]).config.system.build.netboot;
           image-installer = nixpkgs: (nixpkgs.legacyPackages.${system}.nixos [ self.nixosModules.image-installer ]).config.system.build.isoImage;
         in
         {
           netboot-nixos-unstable = netboot nixos-unstable;
           netboot-nixos-stable = netboot nixos-stable;
-          kexec-installer-nixos-unstable = kexec-installer nixos-unstable [ ];
-          kexec-installer-nixos-stable = kexec-installer nixos-stable [ ];
+          kexec-installer-nixos-unstable = kexec-installer nixos-unstable {};
+          kexec-installer-nixos-stable = kexec-installer nixos-stable {};
 
           image-installer-nixos-unstable = image-installer nixos-unstable;
           image-installer-nixos-stable = image-installer nixos-stable;
 
-          kexec-installer-nixos-unstable-noninteractive = kexec-installer nixos-unstable [
-            {
-              system.kexec-installer.name = "nixos-kexec-installer-noninteractive";
-            }
-            self.nixosModules.noninteractive
-          ];
-          kexec-installer-nixos-stable-noninteractive = kexec-installer nixos-stable [
-            {
-              system.kexec-installer.name = "nixos-kexec-installer-noninteractive";
-            }
-            self.nixosModules.noninteractive
-          ];
+          kexec-installer-nixos-unstable-noninteractive = kexec-installer nixos-unstable {
+            _file = __curPos.file;
+            system.kexec-installer.name = "nixos-kexec-installer-noninteractive";
+            imports = [
+              self.nixosModules.noninteractive
+            ];
+          };
+          kexec-installer-nixos-stable-noninteractive = kexec-installer nixos-stable {
+            _file = __curPos.file;
+            system.kexec-installer.name = "nixos-kexec-installer-noninteractive";
+            imports = [
+              self.nixosModules.noninteractive
+            ];
+          };
 
           netboot-installer-nixos-unstable = netboot-installer nixos-unstable;
           netboot-installer-nixos-stable = netboot-installer nixos-stable;

--- a/nix/installer.nix
+++ b/nix/installer.nix
@@ -36,6 +36,8 @@
     # alternative to nixos-generate-config
     # TODO: use nixpkgs again after next nixos release
     (pkgs.callPackage ./nixos-facter.nix {})
+
+    pkgs.disko
   ];
 
   # Don't add nixpkgs to the image to save space, for our intended use case we don't need it

--- a/nix/nixos-facter.nix
+++ b/nix/nixos-facter.nix
@@ -23,13 +23,13 @@ let
 in
 buildGoModule rec {
   pname = "nixos-facter";
-  version = "0.1.0pre";
+  version = "0.1.1";
 
   src = fetchFromGitHub {
     owner = "numtide";
     repo = "nixos-facter";
-    rev = "53cbb6b281c3973faa3c05d1a5a9f957e2cc8187";
-    hash = "sha256-5Gnn2ta/xuht6K8M9weVC0yPw5Wq8AK6wAHmjd1m2i0=";
+    rev = "v${version}";
+    hash = "sha256-vlPmvCrgX64dcf//BPtQszBt7dkq35JpgQg+/LW0AqM=";
   };
 
   vendorHash = "sha256-5leiTNp3FJmgFd0SKhu18hxYZ2G9SuQPhZJjki2SDVs=";


### PR DESCRIPTION
Since disko is just some shell scripts it's comparable small and we can easily embed this everywhere.
We can make use of this in our NixOS tutorials by providing nicer images.