### PR TITLE
kexec-run: set pipefail if the shell supports it

### DIFF
--- a/nix/kexec-installer/kexec-run.sh
+++ b/nix/kexec-installer/kexec-run.sh
@@ -1,6 +1,12 @@
 #!/bin/sh
 
-set -ex
+# Set pipefail if the shell supports it.
+if set -o | grep -q pipefail; then
+  # shellcheck disable=SC3040
+  set -o pipefail
+fi
+set -eux
+
 
 kexec_extra_flags=""
 

--- a/nix/kexec-installer/test.nix
+++ b/nix/kexec-installer/test.nix
@@ -137,7 +137,8 @@ pkgs.testers.runNixOSTest {
     node1.succeed('tar -xf ${kexecTarball}/nixos-kexec-installer-noninteractive-${pkgs.system}.tar.gz -C /root')
     node1.succeed('/root/kexec/ip -V >&2')
     node1.succeed('/root/kexec/kexec --version >&2')
-    node1.succeed('/root/kexec/run >&2')
+    # test with dash here to make sure we don't introduce bashisms
+    node1.succeed('${pkgs.dash}/bin/dash /root/kexec/run >&2')
 
     # wait for kexec to finish
     while ssh(["true"], check=False).returncode == 0:


### PR DESCRIPTION

i.e. we currently don't catch the case where `cpio` is missing on a
system.