### PR TITLE
remove cifs from supported filesystem list

### DIFF
--- a/nix/noninteractive.nix
+++ b/nix/noninteractive.nix
@@ -75,8 +75,8 @@
      boot.supportedFilesystems = [
        "ext4"
        "btrfs"
-       # probably not needed but does not seem to increase closure size
-       "cifs"
+       ## quiet huge dependency closure
+       #"cifs"
        "f2fs"
        ## anyone still using this over ext4?
        #"jfs"

--- a/nix/python-minimal.nix
+++ b/nix/python-minimal.nix
@@ -2,13 +2,7 @@
   nixpkgs.overlays = [
     (final: prev: {
       bcachefs-tools = prev.bcachefs-tools.override { python3 = final.python3Minimal; };
-      cifs-utils = prev.cifs-utils.override { python3 = final.python3Minimal; };
       nfs-utils = prev.nfs-utils.override { python3 = final.python3Minimal; };
-      talloc = prev.talloc.override { python3 = final.python3Minimal; };
-      samba = prev.samba.override { python3Packages = final.python3Minimal.pkgs; };
-      tevent = prev.tevent.override { python3 = final.python3Minimal; };
-      tdb = prev.tdb.override { python3 = final.python3Minimal; };
-      ldb = prev.ldb.override { python3 = final.python3Minimal; };
     })
   ];
 }


### PR DESCRIPTION
samba is like 58MB large and in most cases shouldn't be necessary for installation (most often it would be only used at boot time rather than installation time). People that need samba are probably better off building their own installer. This helps to keep our memory usage again within 1GB