### PR TITLE
kexec-installer: enable zram

### DIFF
--- a/nix/kexec-installer/module.nix
+++ b/nix/kexec-installer/module.nix
@@ -34,6 +34,7 @@ in
 
   config = {
     boot.initrd.compressor = "xz";
+    zramSwap.enable = true; # for low RAM devices.
     # This is a variant of the upstream kexecScript that also allows embedding
     # a ssh key.
     system.build.kexecRun = pkgs.runCommand "kexec-run" { } ''


### PR DESCRIPTION
Handy for installing NixOS on low RAM VPSs via nixos-anywhere.