### PR TITLE
zfs: rename zfsUnstable -> zfs_unstable

### DIFF
--- a/nix/installer.nix
+++ b/nix/installer.nix
@@ -19,7 +19,7 @@
   boot.supportedFilesystems.bcachefs = lib.mkDefault true;
 
   # use latest kernel we can support to get more hardware support
-  boot.zfs.package = pkgs.zfsUnstable;
+  boot.zfs.package = pkgs.zfs_unstable;
 
   documentation.enable = false;
   documentation.man.man-db.enable = false;

--- a/nix/latest-zfs-kernel.nix
+++ b/nix/latest-zfs-kernel.nix
@@ -6,7 +6,7 @@
 }:
 
 let
-  isUnstable = config.boot.zfs.package == pkgs.zfsUnstable;
+  isUnstable = config.boot.zfs.package == pkgs.zfs_unstable;
   zfsCompatibleKernelPackages = lib.filterAttrs (
     name: kernelPackages:
     (builtins.match "linux_[0-9]+_[0-9]+" name) != null

--- a/nix/zfs-minimal.nix
+++ b/nix/zfs-minimal.nix
@@ -1,7 +1,7 @@
 { config, lib, pkgs, ... }:
 # incorperate a space-optimized version of zfs
 let
-  zfs = pkgs.zfsUnstable.override {
+  zfs = pkgs.zfs_unstable.override {
     # this overrides saves 10MB
     samba = pkgs.coreutils;
 


### PR DESCRIPTION
pkgs.zfsUnstable has been renamed to pkgs.zfs_unstable (both in 25.05 and 25.11), but pkgs.zfsUnstable has been removed from 25.11, so this is needed to support 25.11.