### PR TITLE
image-installer: fix wifi mkForce for wpa_supplicant

### DIFF
--- a/nix/image-installer/wifi.nix
+++ b/nix/image-installer/wifi.nix
@@ -1,7 +1,8 @@
+{ lib, ... }:
 {
   imports = [ ../networkd.nix ];
   # use iwd instead of wpa_supplicant
-  networking.wireless.enable = false;
+  networking.wireless.enable = lib.mkForce false;
 
   # Use iwd instead of wpa_supplicant. It has a user friendly CLI
   networking.wireless.iwd = {


### PR DESCRIPTION
## Summary
- Use `lib.mkForce` to disable `wpa_supplicant` in wifi.nix, since `installation-cd-base.nix` enables it and a plain `false` doesn't override it
- Fixes conflict between wpa_supplicant and iwd

## Test plan
- [ ] Build image-installer and verify iwd is used instead of wpa_supplicant