### PR TITLE
Add i686-linux (32-bit) installer support

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -9,7 +9,7 @@
 
   outputs = { self, nixos-unstable, nixos-stable }:
     let
-      supportedSystems = [ "aarch64-linux" "x86_64-linux" ];
+      supportedSystems = [ "aarch64-linux" "i686-linux" "x86_64-linux" ];
       forAllSystems = nixos-unstable.lib.genAttrs supportedSystems;
     in
     {

--- a/nix/image-installer/module.nix
+++ b/nix/image-installer/module.nix
@@ -67,6 +67,17 @@ in
     fi
   '';
 
+  # EFI boot is not available on 32-bit (efivar is broken on i686)
+  isoImage.makeEfiBootable = lib.mkDefault pkgs.stdenv.hostPlatform.is64bit;
+
+  # efivar/efibootmgr from the base profile are broken on i686
+  nixpkgs.overlays = [
+    (final: prev: lib.optionalAttrs prev.stdenv.hostPlatform.is32bit {
+      efivar = prev.emptyDirectory;
+      efibootmgr = prev.emptyDirectory;
+    })
+  ];
+
   # No one got time for xz compression.
   isoImage.squashfsCompression = "zstd";
 } // (if lib.versionAtLeast lib.version "25.03pre" then {

--- a/nix/image-installer/wifi.nix
+++ b/nix/image-installer/wifi.nix
@@ -1,7 +1,8 @@
+{ lib, ... }:
 {
   imports = [ ../networkd.nix ];
   # use iwd instead of wpa_supplicant
-  networking.wireless.enable = false;
+  networking.wireless.enable = lib.mkForce false;
 
   # Use iwd instead of wpa_supplicant. It has a user friendly CLI
   networking.wireless.iwd = {

--- a/nix/installer.nix
+++ b/nix/installer.nix
@@ -15,11 +15,11 @@
   # We are stateless, so just default to latest.
   system.stateVersion = config.system.nixos.release;
 
-  # Enable bcachefs support
-  boot.supportedFilesystems.bcachefs = lib.mkDefault true;
+  # Enable bcachefs support (not available on i686)
+  boot.supportedFilesystems.bcachefs = lib.mkDefault (pkgs.stdenv.hostPlatform.is64bit);
 
   # use latest kernel we can support to get more hardware support
-  boot.zfs.package = pkgs.zfs_unstable;
+  boot.zfs.package = lib.mkIf (lib.meta.availableOn pkgs.stdenv.hostPlatform pkgs.zfs_unstable) pkgs.zfs_unstable;
 
   documentation.enable = false;
   documentation.man.man-db.enable = false;


### PR DESCRIPTION
## Summary
- Add `i686-linux` to `supportedSystems`
- Make bcachefs conditional on 64-bit platforms (not available on i686)
- Make `zfs_unstable` conditional on platform availability
- Depends on #394 (wifi fix)

## Usage
```
nix build .#packages.i686-linux.image-installer-nixos-unstable
```

## Test plan
- [ ] Evaluate: `nix eval .#packages.i686-linux.image-installer-nixos-unstable.name`
- [ ] Build the i686 installer ISO
- [ ] Boot the ISO on a 32-bit machine or VM