### PR TITLE
networkd: disable NetworkManager to avoid racing with systemd-networkd

### DIFF
--- a/nix/kexec-installer/module.nix
+++ b/nix/kexec-installer/module.nix
@@ -34,6 +34,7 @@ in
 
   config = {
     boot.initrd.compressor = "xz";
+    networking.networkmanager.enable = lib.mkForce false;
     # This is a variant of the upstream kexecScript that also allows embedding
     # a ssh key.
     system.build.kexecRun = pkgs.runCommand "kexec-run" { } ''

--- a/nix/netboot-installer/module.nix
+++ b/nix/netboot-installer/module.nix
@@ -11,6 +11,8 @@
   # We are stateless, so just default to latest.
   system.stateVersion = config.system.nixos.release;
 
+  networking.networkmanager.enable = lib.mkForce false;
+
   system.build.netboot = pkgs.symlinkJoin {
     name = "netboot";
     paths = with config.system.build; [


### PR DESCRIPTION
The kexec-installer and netboot-installer variants import both installation-device.nix (which enables NetworkManager) and networkd.nix (which enables systemd-networkd).

After kexec, restore-network.service reapplies the static IP via systemd-networkd, but NetworkManager then activates on the same interface and drops the static route mid-install, breaking nixos-anywhere with "No route to host".

Since these installer variants only use systemd-networkd, force NetworkManager off.