### PR TITLE
kexec-run: leave temporary directory before delayed kexec

### DIFF
--- a/nix/kexec-installer/kexec-run.sh
+++ b/nix/kexec-installer/kexec-run.sh
@@ -105,4 +105,4 @@ else
 fi
 # We will kexec in background so we can cleanly finish the script before the hosts go down.
 # This makes integration with tools like terraform easier.
-nohup sh -c "sleep 6 && '$SCRIPT_DIR/kexec' -e ${kexec_extra_flags}" &
+nohup sh -c "sleep 6 && cd / && '$SCRIPT_DIR/kexec' -e ${kexec_extra_flags}" &


### PR DESCRIPTION
## Summary

Run the delayed `kexec -e` from `/` instead of the temporary directory used
to extend the initrd.

## Problem

`kexec-run.sh` changes into `$INITRD_TMP` and registers an `EXIT` trap that
removes it. The delayed background process inherits that working directory:

```sh
nohup sh -c "sleep 6 && '$SCRIPT_DIR/kexec' -e ${kexec_extra_flags}" &
```

The parent script exits and removes the directory while the background process
is sleeping. The delayed command therefore runs with a deleted working
directory.

Commands invoked through absolute paths can sometimes tolerate this, but shells
or `kexec` implementations that query their current directory fail with errors
such as:

```text
getcwd: cannot access parent directories: No such file or directory
```

This makes the failure dependent on shell and `kexec` behavior and can appear
intermittent across different systems.

The same failure has previously appeared in
nix-community/nixos-anywhere#93 and nix-community/nixos-anywhere#289.

I also reproduced it with an aarch64 kexec image on Debian 13 in Oracle Cloud.
Adding `cd /` allowed the host to enter the NixOS installer successfully.

## Fix

Change to a stable working directory before executing `kexec`:

```sh
nohup sh -c "sleep 6 && cd / && '$SCRIPT_DIR/kexec' -e ${kexec_extra_flags}" &
```
